### PR TITLE
Hotfix/hotfix page share board delete

### DIFF
--- a/src/main/java/com/gnakkeoyhgnus/noteforios/domain/repository/LikesRepository.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/domain/repository/LikesRepository.java
@@ -15,4 +15,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
   Long countByPageShareBoardId(Long pageShareBoardId);
 
   Page<Likes> findByUserId(Long id, Pageable pageable);
+
+  void deleteAllByPageShareBoardId(Long pageShareBoardId);
 }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/domain/repository/LikesRepository.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/domain/repository/LikesRepository.java
@@ -15,6 +15,4 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
   Long countByPageShareBoardId(Long pageShareBoardId);
 
   Page<Likes> findByUserId(Long id, Pageable pageable);
-
-  Optional<Likes> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/service/LikesService.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/service/LikesService.java
@@ -8,6 +8,7 @@ import com.gnakkeoyhgnus.noteforios.domain.repository.LikesRepository;
 import com.gnakkeoyhgnus.noteforios.domain.repository.PageShareBoardRepository;
 import com.gnakkeoyhgnus.noteforios.exception.CustomException;
 import com.gnakkeoyhgnus.noteforios.exception.ErrorCode;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,8 +47,12 @@ public class LikesService {
 
   @Transactional
   public void deleteLikes(User user, Long likesId) {
-    Likes likes = likesRepository.findByIdAndUserId(likesId, user.getId())
+    Likes likes = likesRepository.findById(likesId)
         .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_LIKES));
+
+    if (!Objects.equals(user.getId(), likes.getUser().getId())) {
+      throw new CustomException(ErrorCode.PERMISSION_DENIED_TO_DELETE);
+    }
 
     likesRepository.delete(likes);
   }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/service/PageShareBoardService.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/service/PageShareBoardService.java
@@ -92,6 +92,8 @@ public class PageShareBoardService {
 
     amazonS3Service.deleteAllFileForPageShareBoard(pageShareBoard);
 
+    likesRepository.deleteAllByPageShareBoardId(pageShareBoard.getId());
+
     pageShareBoardRepository.delete(pageShareBoard);
   }
 


### PR DESCRIPTION
## 속지 공유 게시판 삭제
- 속지 공유 게시판을 좋아요 한 데이터가 있으면 FK로 잡혀있어서 속지 공유 게시판이 삭제되지 않는 부분이 있어 수정했습니다.

### 수정 내용
- 속지 공유 게시판 삭제 시 삭제 대상 게시판을 좋아요 한 데이터 삭제 로직 추가

      likesRepository.deleteAllByPageShareBoardId(pageShareBoard.getId());

## 좋아요 삭제
- 좋아요 삭제 시 좋아요 조회를 좋아요 id가 아닌 likesId와 UserId로 하던 로직 좋아요 id로 조회 후 equals로 확인하는 것으로 수정
-> index로 검색하는 검색 시 더 효율이 좋으며 빠름